### PR TITLE
feat: Add server-side verification modal implementation

### DIFF
--- a/api/database/schema.sql
+++ b/api/database/schema.sql
@@ -50,6 +50,7 @@ CREATE TABLE IF NOT EXISTS bus_owner_profiles (
     bus_number VARCHAR(20),
     rc_book_number VARCHAR(100),
     has_completed_onboarding BOOLEAN DEFAULT FALSE,
+    has_seen_verification_modal BOOLEAN DEFAULT FALSE,
     business_name VARCHAR(255),
     license_number VARCHAR(100),
     address TEXT,

--- a/api/routes/bus-owner.js
+++ b/api/routes/bus-owner.js
@@ -115,4 +115,32 @@ router.get('/details', authenticateToken, async (req, res) => {
     }
 });
 
+// POST /api/bus-owner/mark-verification-modal-seen
+// Mark that the user has seen the verification modal
+router.post('/mark-verification-modal-seen', authenticateToken, async (req, res) => {
+    try {
+        const userId = req.user.id;
+
+        // Update the has_seen_verification_modal flag
+        await pool.query(
+            `UPDATE bus_owner_profiles 
+             SET has_seen_verification_modal = true, updated_at = CURRENT_TIMESTAMP
+             WHERE user_id = $1`,
+            [userId]
+        );
+
+        res.json({
+            success: true,
+            message: 'Verification modal marked as seen'
+        });
+
+    } catch (error) {
+        console.error('Mark verification modal seen error:', error);
+        res.status(500).json({
+            success: false,
+            message: 'Failed to mark verification modal as seen. Please try again.'
+        });
+    }
+});
+
 module.exports = router;


### PR DESCRIPTION
- Add has_seen_verification_modal field to bus_owner_profiles table
- Add POST /api/bus-owner/mark-verification-modal-seen endpoint
- Update database schema to support modal tracking
- Implement server-side persistence for one-time modal display